### PR TITLE
remove requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ future==0.17.1
 idna==2.8
 isort==4.3.4
 oauthlib==3.0.1
-pkg-resources==0.0.0
 python-twitter==3.5
 requests==2.21.0
 requests-oauthlib==1.2.0


### PR DESCRIPTION
According to https://stackoverflow.com/questions/39577984/what-is-pkg-resources-0-0-0-in-output-of-pip-freeze-command this is caused by `a bug resulting from Ubuntu providing incorrect metadata to pip` and is safe to remove. It was causing issues for me until I removed it.