### PR TITLE
Consecutive nights

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ $ python camping.py --start-date 2018-07-20 --end-date 2018-07-23 --stdin < park
 
 You'll want to put this script into a 5 minute crontab. You could also grep the output for the success emoji (🏕) and then do something in response, like notify you that there is a campsite available. See the "Twitter Notification" section below.
 
+## Number of nights
+If you're flexible on travel dates, you can search for a specific number of contiguous nights within a wide range of dates. This is useful for campgrounds in high-demand areas (like Yosemite Valley) or during peak season when openings are rare. Simply specify the `--nights` argument. For example, to search for a 5-day reservation in the month of June 2020 at Chisos Basin:
+```
+$ python camping.py --start-date 2020-06-01 --end-date 2020-06-30 --nights 5 234038
+There are campsites available from 2020-06-01 to 2020-06-30!!!
+🏕 CHISOS BASIN (BIG BEND) (234038): 13 site(s) available out of 62 site(s)
+```
+
 ## Getting park IDs
 What you'll want to do is go to https://recreation.gov and search for the campground you want. Click on it in the search sidebar. This should take you to a page for that campground, the URL will look like `https://www.recreation.gov/camping/campgrounds/<number>`. That number is the park ID.
 

--- a/camping.py
+++ b/camping.py
@@ -62,7 +62,7 @@ def get_name_of_site(park_id):
     return resp["campground"]["facility_name"]
 
 
-def get_num_available_sites(resp, start_date, end_date):
+def get_num_available_sites(resp, start_date, end_date, nights):
     maximum = resp["count"]
 
     num_available = 0
@@ -105,7 +105,7 @@ def _main(parks):
         )
         name_of_site = get_name_of_site(park_id)
         current, maximum = get_num_available_sites(
-            park_information, args.start_date, args.end_date
+            park_information, args.start_date, args.end_date, args.nights
         )
         if current:
             emoji = SUCCESS_EMOJI

--- a/camping.py
+++ b/camping.py
@@ -89,9 +89,7 @@ def get_num_available_sites(resp, start_date, end_date, nights):
 
 def consecutive_nights(available, nights):
     grouped = [len(list(g)) for k, g in itertools.groupby(available) if k]
-    if not grouped:
-        return False
-    return nights <= max(grouped)
+    return nights <= max(grouped, default=0)
 
 
 def valid_date(s):

--- a/camping.py
+++ b/camping.py
@@ -64,7 +64,7 @@ def get_name_of_site(park_id):
     return resp["campground"]["facility_name"]
 
 
-def get_num_available_sites(resp, start_date, end_date, nights):
+def get_num_available_sites(resp, start_date, end_date, nights=None):
     global WARN_NIGHTS
     maximum = resp["count"]
 
@@ -120,7 +120,7 @@ def _main(parks):
         )
         name_of_site = get_name_of_site(park_id)
         current, maximum = get_num_available_sites(
-            park_information, args.start_date, args.end_date, args.nights
+            park_information, args.start_date, args.end_date, nights=args.nights
         )
         if current:
             emoji = SUCCESS_EMOJI
@@ -160,7 +160,6 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--nights",
-        default=0,
         help="Number of consecutive nights (default is all nights in the given range).",
         type=int,
     )

--- a/camping.py
+++ b/camping.py
@@ -144,6 +144,12 @@ if __name__ == "__main__":
         type=valid_date,
     )
     parser.add_argument(
+        "--nights",
+        default=0,
+        help="Number of consecutive nights (default is all nights).",
+        type=int,
+    )
+    parser.add_argument(
         dest="parks", metavar="park", nargs="+", help="Park ID(s)", type=int
     )
     parser.add_argument(

--- a/camping.py
+++ b/camping.py
@@ -17,8 +17,6 @@ sh = logging.StreamHandler()
 sh.setFormatter(formatter)
 LOG.addHandler(sh)
 
-WARN_NIGHTS = True
-
 BASE_URL = "https://www.recreation.gov"
 AVAILABILITY_ENDPOINT = "/api/camps/availability/campground/"
 MAIN_PAGE_ENDPOINT = "/api/camps/campgrounds/"
@@ -65,7 +63,6 @@ def get_name_of_site(park_id):
 
 
 def get_num_available_sites(resp, start_date, end_date, nights=None):
-    global WARN_NIGHTS
     maximum = resp["count"]
 
     num_available = 0
@@ -74,9 +71,7 @@ def get_num_available_sites(resp, start_date, end_date, nights=None):
     dates = set(format_date(i) for i in dates)
     if nights not in range(1, num_days + 1): 
         nights = num_days
-        if WARN_NIGHTS:
-            print('Setting number of nights to {}.'.format(nights))
-            WARN_NIGHTS = False
+        LOG.debug('Setting number of nights to {}.'.format(nights))
 
     for site in resp["campsites"].values():
         available = []

--- a/camping.py
+++ b/camping.py
@@ -17,6 +17,7 @@ sh = logging.StreamHandler()
 sh.setFormatter(formatter)
 LOG.addHandler(sh)
 
+WARN_NIGHTS = True
 
 BASE_URL = "https://www.recreation.gov"
 AVAILABILITY_ENDPOINT = "/api/camps/availability/campground/"
@@ -64,6 +65,7 @@ def get_name_of_site(park_id):
 
 
 def get_num_available_sites(resp, start_date, end_date, nights):
+    global WARN_NIGHTS
     maximum = resp["count"]
 
     num_available = 0
@@ -72,6 +74,10 @@ def get_num_available_sites(resp, start_date, end_date, nights):
     dates = set(format_date(i) for i in dates)
     if nights not in range(1, num_days + 1): 
         nights = num_days
+        if WARN_NIGHTS:
+            print('Setting number of nights to {}.'.format(nights))
+            WARN_NIGHTS = False
+
     for site in resp["campsites"].values():
         available = []
         for date, status in site["availabilities"].items():

--- a/camping.py
+++ b/camping.py
@@ -5,6 +5,7 @@ import json
 import logging
 import sys
 from datetime import datetime, timedelta
+import itertools
 
 import requests
 from fake_useragent import UserAgent
@@ -81,6 +82,13 @@ def get_num_available_sites(resp, start_date, end_date, nights):
             num_available += 1
             LOG.debug("Available site {}: {}".format(num_available, json.dumps(site, indent=1)))
     return num_available, maximum
+
+
+def consecutive_nights(available, nights):
+    grouped = [len(list(g)) for k, g in itertools.groupby(available) if k]
+    if not grouped:
+        return False
+    return nights <= max(grouped)
 
 
 def valid_date(s):

--- a/camping.py
+++ b/camping.py
@@ -161,7 +161,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--nights",
         default=0,
-        help="Number of consecutive nights (default is all nights).",
+        help="Number of consecutive nights (default is all nights in the given range).",
         type=int,
     )
     parser.add_argument(

--- a/camping.py
+++ b/camping.py
@@ -100,6 +100,12 @@ def valid_date(s):
         msg = "Not a valid date: '{0}'.".format(s)
         raise argparse.ArgumentTypeError(msg)
 
+def positive_int(i):
+    i = int(i)
+    if i <= 0:
+        msg = "Not a valid number of nights: {0}".format(i)
+        raise argparse.ArgumentTypeError(msg)
+    return i
 
 def _main(parks):
     out = []
@@ -156,7 +162,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--nights",
         help="Number of consecutive nights (default is all nights in the given range).",
-        type=int,
+        type=positive_int,
     )
     parser.add_argument(
         dest="parks", metavar="park", nargs="+", help="Park ID(s)", type=int

--- a/camping.py
+++ b/camping.py
@@ -70,15 +70,18 @@ def get_num_available_sites(resp, start_date, end_date, nights):
     num_days = (end_date - start_date).days
     dates = [end_date - timedelta(days=i) for i in range(1, num_days + 1)]
     dates = set(format_date(i) for i in dates)
+    if nights not in range(1, num_days + 1): 
+        nights = num_days
     for site in resp["campsites"].values():
-        available = bool(len(site["availabilities"]))
+        available = []
         for date, status in site["availabilities"].items():
             if date not in dates:
                 continue
-            if status != "Available":
-                available = False
-                break
-        if available:
+            if status == "Available":
+                available.append(True)
+            else:
+                available.append(False)
+        if consecutive_nights(available, nights):
             num_available += 1
             LOG.debug("Available site {}: {}".format(num_available, json.dumps(site, indent=1)))
     return num_available, maximum


### PR DESCRIPTION
PR for #15. Created an optional --nights input argument to specify the minimum number of contiguous nights to search between dates. Without --nights specified, defaults to original behavior (all nights between --start-date and --end-date).

Example finding spots in Upper Pines, Yosemite this week:
```
$ python camping.py --start-date 2020-03-10 --end-date 2020-03-19 --nights 2 232447
There are campsites available from 2020-03-10 to 2020-03-19!!!
🏕 UPPER PINES (232447): 9 site(s) available out of 240 site(s)

$ python camping.py --start-date 2020-03-10 --end-date 2020-03-19 --nights 3 232447
There are campsites available from 2020-03-10 to 2020-03-19!!!
🏕 UPPER PINES (232447): 1 site(s) available out of 240 site(s)
```

Will warn the user if they give an incorrect number of nights
```
$ python camping.py --start-date 2020-03-15 --end-date 2020-03-17 --nights 5 232447
Setting number of nights to 2.
There are campsites available from 2020-03-15 to 2020-03-17!!!
🏕 UPPER PINES (232447): 2 site(s) available out of 240 site(s)
```

Without specifying `--nights`, defaults to old behavior (all nights between given dates):
```
$ python camping.py --start-date 2020-06-28 --end-date 2020-06-30 234038
There are campsites available from 2020-06-28 to 2020-06-30!!!
🏕 CHISOS BASIN (BIG BEND) (234038): 27 site(s) available out of 62 site(s)
```

This definitely needs review and testing, but so far seems to be working okay on my end. It does require itertools for some list comprehension, unless we figure out a simpler way than my approach :)