### PR TITLE
Fix issue #9

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This script scrapes the https://recreation.gov website for campsite availabiliti
 
 ## Example Usage
 ```
-$ python camping.py --start-date 2018-07-20 --end-date 2018-07-23 232448 232450 232447 232770
+$ python camping.py --start-date 2018-07-20 --end-date 2018-07-23 --parks 232448 232450 232447 232770
 ❌ TUOLUMNE MEADOWS: 0 site(s) available out of 148 site(s)
 🏕 LOWER PINES: 11 site(s) available out of 73 site(s)
 ❌ UPPER PINES: 0 site(s) available out of 235 site(s)

--- a/camping.py
+++ b/camping.py
@@ -143,10 +143,17 @@ if __name__ == "__main__":
         help="End date [YYYY-MM-DD]. You expect to leave this day, not stay the night.",
         type=valid_date,
     )
-    parser.add_argument(
-        dest="parks", metavar="park", nargs="+", help="Park ID(s)", type=int
+
+    parks_group = parser.add_mutually_exclusive_group(required=True)
+    parks_group.add_argument(
+        "--parks",
+        dest="parks",
+        metavar="park",
+        nargs="+",
+        help="Park ID(s)",
+        type=int,
     )
-    parser.add_argument(
+    parks_group.add_argument(
         "--stdin",
         "-",
         action="store_true",


### PR DESCRIPTION
Created mutually exclusive group for parks and stdin to fix issue #9 .  

Had to make parks argument optional as required by being part of mutually exclusive group, but I made the group required so --parks or --stdin must be used.

Updated README to reflect using the --parks option

First time using argparse (and first PR) so I'd love to hear ideas if there is a better approach

