### PR TITLE
Use date format expected by recreation.gov API

### DIFF
--- a/camping.py
+++ b/camping.py
@@ -23,7 +23,7 @@ AVAILABILITY_ENDPOINT = "/api/camps/availability/campground/"
 MAIN_PAGE_ENDPOINT = "/api/camps/campgrounds/"
 
 INPUT_DATE_FORMAT = "%Y-%m-%d"
-ISO_DATE_FORMAT = "%Y-%m-%dT00:00:00Z"
+ISO_DATE_FORMAT = "%Y-%m-%dT00:00:00.000Z"
 
 SUCCESS_EMOJI = "🏕"
 FAILURE_EMOJI = "❌"


### PR DESCRIPTION
The recreation.gov API expects dates with milliseconds, otherwise it returns a 400 error with the response:
```
{"error":"Invalid Date Format"}
```

This PR adds the milliseconds expected, so we can again get valid responses from the API.