### PR TITLE
problem calculating max campsites availability with fully booked campsites

### DIFF
--- a/camping.py
+++ b/camping.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import logging
 import sys
-from datetime import date, datetime, timedelta
+from datetime import datetime, timedelta
 from dateutil import rrule
 from itertools import count, groupby
 
@@ -95,6 +95,7 @@ def get_park_information(park_id, start_date, end_date, campsite_type=None):
     for month_data in api_data:
         for campsite_id, campsite_data in month_data["campsites"].items():
             available = []
+            a = data.setdefault(campsite_id, [])
             for date, availability_value in campsite_data["availabilities"].items():
                 if availability_value != "Available":
                     continue
@@ -102,7 +103,6 @@ def get_park_information(park_id, start_date, end_date, campsite_type=None):
                     continue
                 available.append(date)
             if available:
-                a = data.setdefault(campsite_id, [])
                 a += available
 
     return data


### PR DESCRIPTION
If a campsite is unavailable for an entire month, it will not be counted towards the maximum available campsites for a given park.  This is because ```get_park_information()``` will only create an entry in the ```data``` dictionary for a campsite once the first availability is found.

Before PR:

```
(venv) $ python3 camping.py --start-date 2021-06-01 --end-date 2021-06-02 --parks 232463 --debug
2021-03-04 12:24:23,642 - 9679 - DEBUG - Querying for 232463 with these params: {'start_date': '2021-06-01T00:00:00.000Z'}
2021-03-04 12:24:25,326 - 9679 - DEBUG - Information for park 232463: {}
2021-03-04 12:24:25,505 - 9679 - DEBUG - Setting number of nights to 1.
There are no campsites available :(
❌ MORAINE PARK CAMPGROUND (232463): 0 site(s) available out of 0 site(s)
```

After PR:

```
(venv) $ python3 camping.py --start-date 2021-06-01 --end-date 2021-06-02 --parks 232463 --debug
2021-03-04 12:25:12,545 - 9923 - DEBUG - Querying for 232463 with these params: {'start_date': '2021-06-01T00:00:00.000Z'}
2021-03-04 12:25:14,146 - 9923 - DEBUG - Information for park 232463: {
  "2270": [],
<SNIP: removed 251 keys with empty lists as values> 
  "2170": []
}
2021-03-04 12:30:26,826 - 13501 - DEBUG - Setting number of nights to 1.
There are no campsites available :(
❌ MORAINE PARK CAMPGROUND (232463): 0 site(s) available out of 253 site(s)
```

You can see from this link that MORAINE PARK CAMPGROUND has 253 available sites:
https://www.recreation.gov/camping/campgrounds/232463/availability

I have [attached](https://github.com/banool/recreation-gov-campsite-checker/files/6087836/availability.json.txt) the park information json I was receiving at the time I experienced this issue.

