### PR TITLE
Fix off-by-one error when calculating consecutive nights

### DIFF
--- a/camping.py
+++ b/camping.py
@@ -182,12 +182,12 @@ def consecutive_nights(available, nights):
         # Skip ranges that are too short.
         if len(r) < nights:
             continue
-        for start_index in range(0, len(r) - nights):
+        for start_index in range(0, len(r) - nights + 1):
             start_nice = format_date(
                 datetime.fromordinal(r[start_index]), format_string=INPUT_DATE_FORMAT
             )
             end_nice = format_date(
-                datetime.fromordinal(r[start_index + nights]),
+                datetime.fromordinal(r[start_index + nights - 1] + 1),
                 format_string=INPUT_DATE_FORMAT,
             )
             long_enough_consecutive_ranges.append((start_nice, end_nice))


### PR DESCRIPTION
Since the actual end date doesn't need to be available, we only need to check the day before the end date.

Should fix issue #29 