### PR TITLE
Defined Python source code encoding to fix "SyntaxError: Non-ASCII

### DIFF
--- a/camping.py
+++ b/camping.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 #!/usr/bin/env python3
 
 import argparse


### PR DESCRIPTION
character '\xf0'".