### PR TITLE
Script now returns 0 on success and non-zero when an exception occurs…

### DIFF
--- a/camping.py
+++ b/camping.py
@@ -295,5 +295,4 @@ if __name__ == "__main__":
     if args.debug:
         LOG.setLevel(logging.DEBUG)
 
-    code = 0 if main(args.parks, json_output=args.json_output) else 1
-    sys.exit(code)
+    main(args.parks, json_output=args.json_output)


### PR DESCRIPTION
… to reflect standard shell behavior.

See https://github.com/banool/recreation-gov-campsite-checker/issues/46.