### PR TITLE
Add Discord Webhook notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ python -m unittest
 - Works with any park out of the box, not just those in Yosemite like with the original.
 - **Update 2018-10-21:** Works with the new recreation.gov site.
 
+## Discord Notification
+If you want to be notified for any available campsites via Discord, you can do so using a Discord Webhook.
+
+1. Find a channel in your Discord server you want the scraper to post to, and go to `Edit Channel -> Integrations -> Webhooks -> New Webhook`.
+2. Name the webhook whatever you like (optionally set an avatar). Copy the Webhook URL using the button below the Name field.
+3. Provide the webhook url as the argument `--discord-webhook` to the `camping.py` script alongside your other args. For example:
+
+`python camping.py --start-date 2022-12-01 --end-date 2022-12-31 --discord-webhook https://discord.com/api/webhooks/...`
+
+The bot will only post messages for campsites that have availability given your provided constraints, and provide links directly to the available campsite pages for your convenience.
+
 ## Twitter Notification
 If you want to be notified about campsite availabilities via Twitter (they're the only API out there that is actually easy to use), you can do this:
 1. Make an app via Twitter. It's pretty easy, go to: https://apps.twitter.com/app/new.

--- a/camping.py
+++ b/camping.py
@@ -8,13 +8,13 @@ from datetime import datetime, timedelta
 from itertools import count, groupby
 
 from dateutil import rrule
+from discord_webhook import DiscordWebhook
 
 from clients.recreation_client import RecreationClient
 from enums.date_format import DateFormat
 from enums.emoji import Emoji
 from utils import formatter
 from utils.camping_argparser import CampingArgumentParser
-from discord_webhook import DiscordWebhook
 
 LOG = logging.getLogger(__name__)
 log_formatter = logging.Formatter(
@@ -262,6 +262,7 @@ def generate_json_output(info_by_park_id):
 
     return json.dumps(availabilities_by_park_id), has_availabilities
 
+
 def generate_discord_output(info_by_park_id):
     out = ""
     has_availabilities = False
@@ -279,7 +280,8 @@ def generate_discord_output(info_by_park_id):
 
     return out, has_availabilities
 
-def main(parks, json_output=False, discord_webhook_url=''):
+
+def main(parks, json_output=False, discord_webhook_url=""):
     info_by_park_id = {}
     for park_id in parks:
         info_by_park_id[park_id] = check_park(
@@ -291,14 +293,14 @@ def main(parks, json_output=False, discord_webhook_url=''):
             nights=args.nights,
         )
 
-    if discord_webhook_url != '':
+    if discord_webhook_url != "":
         content, has_availabilities = generate_discord_output(info_by_park_id)
         if has_availabilities:
             webhook = DiscordWebhook(url=discord_webhook_url, content=content)
             response = webhook.execute()
             print(response)
         else:
-            print('No campsites found; not issuing Discord webhook request')
+            print("No campsites found; not issuing Discord webhook request")
 
     if json_output:
         output, has_availabilities = generate_json_output(info_by_park_id)
@@ -320,4 +322,8 @@ if __name__ == "__main__":
     if args.debug:
         LOG.setLevel(logging.DEBUG)
 
-    main(args.parks, json_output=args.json_output, discord_webhook_url=args.discord_webhook)
+    main(
+        args.parks,
+        json_output=args.json_output,
+        discord_webhook_url=args.discord_webhook,
+    )

--- a/camping.py
+++ b/camping.py
@@ -3,7 +3,6 @@
 
 import json
 import logging
-import sys
 from collections import defaultdict
 from datetime import datetime, timedelta
 from itertools import count, groupby
@@ -15,6 +14,7 @@ from enums.date_format import DateFormat
 from enums.emoji import Emoji
 from utils import formatter
 from utils.camping_argparser import CampingArgumentParser
+from discord_webhook import DiscordWebhook
 
 LOG = logging.getLogger(__name__)
 log_formatter = logging.Formatter(
@@ -262,8 +262,24 @@ def generate_json_output(info_by_park_id):
 
     return json.dumps(availabilities_by_park_id), has_availabilities
 
+def generate_discord_output(info_by_park_id):
+    out = ""
+    has_availabilities = False
+    for park_id, info in info_by_park_id.items():
+        current, maximum, _, park_name = info
+        if current:
+            has_availabilities = True
+            out += "{emoji} [{park_name}](https://www.recreation.gov/camping/campgrounds/{park_id}): {current} site(s) available out of {maximum} site(s)\n".format(
+                emoji=Emoji.SUCCESS.value,
+                park_name=park_name,
+                park_id=park_id,
+                current=current,
+                maximum=maximum,
+            )
 
-def main(parks, json_output=False):
+    return out, has_availabilities
+
+def main(parks, json_output=False, discord_webhook_url=''):
     info_by_park_id = {}
     for park_id in parks:
         info_by_park_id[park_id] = check_park(
@@ -274,6 +290,15 @@ def main(parks, json_output=False):
             args.campsite_ids,
             nights=args.nights,
         )
+
+    if discord_webhook_url != '':
+        content, has_availabilities = generate_discord_output(info_by_park_id)
+        if has_availabilities:
+            webhook = DiscordWebhook(url=discord_webhook_url, content=content)
+            response = webhook.execute()
+            print(response)
+        else:
+            print('No campsites found; not issuing Discord webhook request')
 
     if json_output:
         output, has_availabilities = generate_json_output(info_by_park_id)
@@ -295,4 +320,4 @@ if __name__ == "__main__":
     if args.debug:
         LOG.setLevel(logging.DEBUG)
 
-    main(args.parks, json_output=args.json_output)
+    main(args.parks, json_output=args.json_output, discord_webhook_url=args.discord_webhook)

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ six==1.15.0
 soupsieve==1.8
 toml==0.10.0
 urllib3==1.24.2
+discord-webhook==0.16.3

--- a/utils/camping_argparser.py
+++ b/utils/camping_argparser.py
@@ -55,7 +55,15 @@ class CampingArgumentParser(argparse.ArgumentParser):
                 "This make the script output JSON instead of human readable "
                 "output. Note, this is incompatible with the twitter notifier. "
                 "This output includes more precise information, such as the exact "
-                "avaiable dates and which sites are available."
+                "available dates and which sites are available."
+            ),
+        )
+        self.add_argument(
+            "--discord-webhook",
+            type=str,
+            nargs=1,
+            help=(
+                "Discord URL webhook to invoke when a campsite is found."
             ),
         )
         parks_group = self.add_mutually_exclusive_group(required=True)

--- a/utils/camping_argparser.py
+++ b/utils/camping_argparser.py
@@ -62,9 +62,7 @@ class CampingArgumentParser(argparse.ArgumentParser):
             "--discord-webhook",
             type=str,
             nargs=1,
-            help=(
-                "Discord URL webhook to invoke when a campsite is found."
-            ),
+            help=("Discord URL webhook to invoke when a campsite is found."),
         )
         parks_group = self.add_mutually_exclusive_group(required=True)
         parks_group.add_argument(


### PR DESCRIPTION
Adds functionality to invoke a Discord webhook and post to a channel whenever a campsite is found

The image below is what a user would see in their Discord channel if a campsite is found (this image shows 0 sites purely because of testing; *the bot does not post Discord messages at all if no sites are found*)

![Untitled](https://user-images.githubusercontent.com/9044037/170082178-4fb097c1-0b76-467e-af47-3cb9843f100f.png)

