### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ You can also take [this site for a spin](https://pastudan.github.io/national-par
 ## Installation
 
 I wrote this in Python 3.7 but I've tested it as working with 3.5 and 3.6 also.
+It is best to use 3.9+
 ```
 python3 -m venv myvenv
 source myvenv/bin/activate


### PR DESCRIPTION
Type annotation in "camping.py" line 275 crashes in python 3.8 and under. (at least for me...). 
work ok for 3.9+. see https://github.com/banool/recreation-gov-campsite-checker/issues/59