### PR TITLE
Fix dependency issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,10 @@ isort==4.3.4
 oauthlib==3.0.1
 python-dateutil==2.8.1
 python-twitter==3.5
-requests==2.21.0
+requests==2.32.3
 requests-oauthlib==1.2.0
-six==1.15.0
+six==1.16.0
 soupsieve==1.8
 toml==0.10.0
-urllib3==1.24.2
+urllib3==2.2.2
 user_agent


### PR DESCRIPTION
This project, as it currently stands, does not successfully run due to dependency conflicts between `requests`, `urllib3`, and `six`. Bumping all of those up to their latest stable versions returns the project to a healthy state.